### PR TITLE
Add multi-argument support to enable and disable extensions

### DIFF
--- a/gnome-shell-extension-cl
+++ b/gnome-shell-extension-cl
@@ -123,59 +123,77 @@ function version_greater() {
 
 
 function disable_extension() {
-    extension_to_disable=$1
-    if  [ "$(check_extension_in_all_extensions "$extension_to_disable")" = false ]
-    then
-        echo "'$extension_to_disable' is not installed."
-        return
-    fi
-    if  [ "$(check_extension_is_enabled "$extension_to_disable")" = false ]
-    then
-        echo "'$extension_to_disable' is already disabled."
-        return
-    fi
-    if [ "$(version_greater)" = true ]
-    then
-        gnome-shell-extension-tool -d "$extension_to_disable"
-        return
-    fi
-    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
-                               tr -d "[",",","]","\'") )
-    enabled_extensions_string=""
-    for enabled_extension in "${enabled_extensions[@]}"
-    do
-        if [ "$enabled_extension" != "$extension_to_disable" ]
-        then
-            enabled_extensions_string="$enabled_extensions_string '$enabled_extension', "
-        fi
-    done
-    enabled_extensions_string=${enabled_extensions_string:1:-2}
-    enabled_extensions_string="[ $enabled_extensions_string ]"
 
-    dbus-launch gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+    arguments=("$@")
+    unset "arguments[0]"
+
+    for extension_to_disable in "${arguments[@]}"
+    do
+
+        if  [ "$(check_extension_in_all_extensions "$extension_to_disable")" = false ]
+        then
+            echo "'$extension_to_disable' is not installed."
+            continue
+        fi
+        if  [ "$(check_extension_is_enabled "$extension_to_disable")" = false ]
+        then
+            echo "'$extension_to_disable' is already disabled."
+            continue
+        fi
+        if [ "$(version_greater)" = true ]
+        then
+            gnome-shell-extension-tool -d "$extension_to_disable"
+            continue
+        fi
+        enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+                                   tr -d "[",",","]","\'") )
+        enabled_extensions_string=""
+        for enabled_extension in "${enabled_extensions[@]}"
+        do
+            if [ "$enabled_extension" != "$extension_to_disable" ]
+            then
+                enabled_extensions_string="$enabled_extensions_string '$enabled_extension', "
+            fi
+        done
+        enabled_extensions_string=${enabled_extensions_string:1:-2}
+        enabled_extensions_string="[ $enabled_extensions_string ]"
+
+        dbus-launch gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+
+    done
+    return
 }
 
 
 function enable_extension() {
-    extension_to_enable=$1
-    if  [ "$(check_extension_in_all_extensions "$extension_to_enable")" = false ]
-    then
-        echo "'$extension_to_enable' is not installed."
-        return
-    fi
-    if  [ "$(check_extension_is_enabled "$extension_to_enable")" = true ]
-    then
-        echo "'$extension_to_enable' is already enabled."
-        return
-    fi
-    if [ "$(version_greater)" = true ]
-    then
-        gnome-shell-extension-tool -e "$extension_to_enable"
-        return
-    fi
-    enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
-    enabled_extensions_string="$enabled_extensions_string, '$extension_to_enable' ]"
-    gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+
+    arguments=("$@")
+    unset "arguments[0]"
+
+    for extension_to_enable in "${arguments[@]}"
+    do
+
+        if  [ "$(check_extension_in_all_extensions "$extension_to_enable")" = false ]
+        then
+            echo "'$extension_to_enable' is not installed."
+            continue
+        fi
+        if  [ "$(check_extension_is_enabled "$extension_to_enable")" = true ]
+        then
+            echo "'$extension_to_enable' is already enabled."
+            continue
+        fi
+        if [ "$(version_greater)" = true ]
+        then
+            gnome-shell-extension-tool -e "$extension_to_enable"
+            continue
+        fi
+        enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
+        enabled_extensions_string="$enabled_extensions_string, '$extension_to_enable' ]"
+        gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+
+    done
+    return
 }
 
 
@@ -227,10 +245,10 @@ case $1 in
         print_help
         ;;
     -e|--enable-extension)
-        enable_extension "$2"
+        enable_extension "$@"
         ;;
     -d|--disable-extension)
-        disable_extension "$2"
+        disable_extension "$@"
         ;;
     -da|--disable-all-extensions)
         disable_all_extensions

--- a/gnome-shell-extension-cl
+++ b/gnome-shell-extension-cl
@@ -12,170 +12,170 @@
 # -------------------------------------------------------------------------------
 
 function get_enabled_extensions() {
-	  enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
                                sed -e 's|^@as ||g' | tr -d "[",",","]","\'") )
 }
 
 
 function print_enabled_extensions(){
     get_enabled_extensions
-	  for enabled_extension in "${enabled_extensions[@]}"
-	  do
-		    echo "$enabled_extension"
-	  done
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        echo "$enabled_extension"
+    done
 }
 
 
 # -------------------------------------------------------------------------------
 
 function get_installed_extensions() {
-	  global_installed_extensions=( $(find "/usr/share/gnome-shell/extensions/" \
+    global_installed_extensions=( $(find "/usr/share/gnome-shell/extensions/" \
                                          -maxdepth 1 -type d -name "*@*" -exec \
                                          /usr/bin/basename {} \;) )
-	  local_installed_extensions=( $(find "/home/$USER/.local/share/gnome-shell/extensions/" \
+    local_installed_extensions=( $(find "/home/$USER/.local/share/gnome-shell/extensions/" \
                                         -maxdepth 1 -type d -name "*@*" -exec \
                                         /usr/bin/basename {} \;) )
 
-	  if [ ${#local_installed_extensions[@]} -gt ${#global_installed_extensions[@]} ]
-	  then
-		    installed_extensions=( ${local_installed_extensions[@]} )
-		    test_extensions=( ${global_installed_extensions[@]} )
-	  else
-		    installed_extensions=( ${global_installed_extensions[@]} )
-		    test_extensions=( ${local_installed_extensions[@]} )
-	  fi
-	  for test_extension in "${test_extensions[@]}"
-	  do
-		    test_extension_not_doubled=true
-		    for installed_extension in "${installed_extensions[@]}"
-		    do
-		        if [ "$test_extension" = "$installed_extension" ]
-			      then
-				        test_extension_not_doubled=false
-				        break
-			      fi
-		    done
-		    if  [ $test_extension_not_doubled = true ]
-		    then
-			      test_extension=( $test_extension )
-			      installed_extensions=( "${installed_extensions[@]}" "${test_extension[@]}" )
-			      #echo ${test_extension[@]}
-		    fi
-	  done
-	  echo "${installed_extensions[@]}"
+    if [ ${#local_installed_extensions[@]} -gt ${#global_installed_extensions[@]} ]
+    then
+        installed_extensions=( ${local_installed_extensions[@]} )
+        test_extensions=( ${global_installed_extensions[@]} )
+    else
+        installed_extensions=( ${global_installed_extensions[@]} )
+        test_extensions=( ${local_installed_extensions[@]} )
+    fi
+    for test_extension in "${test_extensions[@]}"
+    do
+        test_extension_not_doubled=true
+        for installed_extension in "${installed_extensions[@]}"
+        do
+            if [ "$test_extension" = "$installed_extension" ]
+            then
+                test_extension_not_doubled=false
+                break
+            fi
+        done
+        if  [ $test_extension_not_doubled = true ]
+        then
+            test_extension=( $test_extension )
+            installed_extensions=( "${installed_extensions[@]}" "${test_extension[@]}" )
+            #echo ${test_extension[@]}
+        fi
+    done
+    echo "${installed_extensions[@]}"
 }
 
 
 function print_installed_extensions() {
-	  installed_extensions=( $(get_installed_extensions) )
-	  for installed_extension in "${installed_extensions[@]}"
-	  do
-	      [ "$(check_extension_is_enabled "$installed_extension")" = true ] && \
+    installed_extensions=( $(get_installed_extensions) )
+    for installed_extension in "${installed_extensions[@]}"
+    do
+        [ "$(check_extension_is_enabled "$installed_extension")" = true ] && \
             status="enabled" || status="disabled";
-		    printf "%-65s - %-10s \n" "$installed_extension" "$status"
-	  done
+        printf "%-65s - %-10s \n" "$installed_extension" "$status"
+    done
 }
 
 
 # -------------------------------------------------------------------------------
 
 function check_extension_is_enabled() {
-	  extension_to_check=$1
-	  enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+    extension_to_check=$1
+    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
                                sed -e 's|^@as ||g' | tr -d "[",",","]","\'") )
-	  for enabled_extension in "${enabled_extensions[@]}"
-	  do
-		    if [ "$enabled_extension" = "$extension_to_check" ]
-		    then
-			      echo true
-			      return
-		    fi
-	  done
-	  echo false
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        if [ "$enabled_extension" = "$extension_to_check" ]
+        then
+            echo true
+            return
+        fi
+    done
+    echo false
 }
 
 
 function check_extension_in_all_extensions() {
-	  extension_to_check=$1
-	  installed_extensions=( $(get_installed_extensions) )
-	  for installed_extension in "${installed_extensions[@]}"
-	  do
-		    if [ "$installed_extension" = "$extension_to_check" ]
-		    then
-			      echo true
-			      return
-		    fi
-	  done
-	  echo false
+    extension_to_check=$1
+    installed_extensions=( $(get_installed_extensions) )
+    for installed_extension in "${installed_extensions[@]}"
+    do
+        if [ "$installed_extension" = "$extension_to_check" ]
+        then
+            echo true
+            return
+        fi
+    done
+    echo false
 }
 
 
 function version_greater() {
-	  minimal_version=3.18.0
-	  our_version=$(gnome-shell --version | awk '{print $3}')
-	  if [ "$(echo "$our_version $minimal_version" | tr " " "\n" | sort -V | head -n 1)" != "$our_version" ]
-	  then
-		    echo true
-	  else
-		    echo false
-	  fi
+    minimal_version=3.18.0
+    our_version=$(gnome-shell --version | awk '{print $3}')
+    if [ "$(echo "$our_version $minimal_version" | tr " " "\n" | sort -V | head -n 1)" != "$our_version" ]
+    then
+        echo true
+    else
+        echo false
+    fi
 }
 
 
 function disable_extension() {
-	  extension_to_disable=$1
-	  if  [ "$(check_extension_in_all_extensions "$extension_to_disable")" = false ]
-	  then
-		    echo "'$extension_to_disable' is not installed."
-		    return
-	  fi
-	  if  [ "$(check_extension_is_enabled "$extension_to_disable")" = false ]
-	  then
-		    echo "'$extension_to_disable' is already disabled."
-		    return
-	  fi
-	  if [ "$(version_greater)" = true ]
-	  then
-		    gnome-shell-extension-tool -d "$extension_to_disable"
-		    return
-	  fi
-	  enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
+    extension_to_disable=$1
+    if  [ "$(check_extension_in_all_extensions "$extension_to_disable")" = false ]
+    then
+        echo "'$extension_to_disable' is not installed."
+        return
+    fi
+    if  [ "$(check_extension_is_enabled "$extension_to_disable")" = false ]
+    then
+        echo "'$extension_to_disable' is already disabled."
+        return
+    fi
+    if [ "$(version_greater)" = true ]
+    then
+        gnome-shell-extension-tool -d "$extension_to_disable"
+        return
+    fi
+    enabled_extensions=( $(gsettings get org.gnome.shell enabled-extensions | \
                                tr -d "[",",","]","\'") )
-	  enabled_extensions_string=""
-	  for enabled_extension in "${enabled_extensions[@]}"
-	  do
-		    if [ "$enabled_extension" != "$extension_to_disable" ]
-		    then
-		        enabled_extensions_string="$enabled_extensions_string '$enabled_extension', "
-		    fi
-	  done
-	  enabled_extensions_string=${enabled_extensions_string:1:-2}
-	  enabled_extensions_string="[ $enabled_extensions_string ]"
+    enabled_extensions_string=""
+    for enabled_extension in "${enabled_extensions[@]}"
+    do
+        if [ "$enabled_extension" != "$extension_to_disable" ]
+        then
+            enabled_extensions_string="$enabled_extensions_string '$enabled_extension', "
+        fi
+    done
+    enabled_extensions_string=${enabled_extensions_string:1:-2}
+    enabled_extensions_string="[ $enabled_extensions_string ]"
 
-	  dbus-launch gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+    dbus-launch gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
 }
 
 
 function enable_extension() {
-	  extension_to_enable=$1
-	  if  [ "$(check_extension_in_all_extensions "$extension_to_enable")" = false ]
-	  then
-		    echo "'$extension_to_enable' is not installed."
-		    return
-	  fi
-	  if  [ "$(check_extension_is_enabled "$extension_to_enable")" = true ]
-	  then
-		    echo "'$extension_to_enable' is already enabled."
-		    return
-	  fi
-	  if [ "$(version_greater)" = true ]
-	  then
-		    gnome-shell-extension-tool -e "$extension_to_enable"
-		    return
-	  fi
-	  enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
-	  enabled_extensions_string="$enabled_extensions_string, '$extension_to_enable' ]"
-	  gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
+    extension_to_enable=$1
+    if  [ "$(check_extension_in_all_extensions "$extension_to_enable")" = false ]
+    then
+        echo "'$extension_to_enable' is not installed."
+        return
+    fi
+    if  [ "$(check_extension_is_enabled "$extension_to_enable")" = true ]
+    then
+        echo "'$extension_to_enable' is already enabled."
+        return
+    fi
+    if [ "$(version_greater)" = true ]
+    then
+        gnome-shell-extension-tool -e "$extension_to_enable"
+        return
+    fi
+    enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
+    enabled_extensions_string="$enabled_extensions_string, '$extension_to_enable' ]"
+    gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
 }
 
 
@@ -183,7 +183,7 @@ function enable_extension() {
 
 function disable_all_extensions() {
     get_enabled_extensions
-	  for enabled_extension in "${enabled_extensions[@]}"
+    for enabled_extension in "${enabled_extensions[@]}"
     do
         # Don't disable user-theme extensions to avoid breaking them
         if [ "$enabled_extension" != "user-theme" ] && \
@@ -223,34 +223,34 @@ Options
 # -------------------------------------------------------------------------------
 
 case $1 in
-	  -h|--help)
-		    print_help
-		    ;;
-	  -e|--enable-extension)
-		    enable_extension "$2"
-	      ;;
-	  -d|--disable-extension)
-		    disable_extension "$2"
-		    ;;
+    -h|--help)
+        print_help
+        ;;
+    -e|--enable-extension)
+        enable_extension "$2"
+        ;;
+    -d|--disable-extension)
+        disable_extension "$2"
+        ;;
     -da|--disable-all-extensions)
         disable_all_extensions
         ;;
-	  -le|--simple-list-enabled)
-		    print_enabled_extensions
-		    ;;
-	  -l|--list)
-		    print_installed_extensions
-		    ;;
-	  -s|--status)
-		    if  [ "$(check_extension_is_enabled "$2")" = true ]
-		    then
-			      echo "enabled"
-		    else
-			      echo "disabled"
-		    fi
+    -le|--simple-list-enabled)
+        print_enabled_extensions
         ;;
-	  *)
-		    print_help
-		    ;;
+    -l|--list)
+        print_installed_extensions
+        ;;
+    -s|--status)
+        if  [ "$(check_extension_is_enabled "$2")" = true ]
+        then
+            echo "enabled"
+        else
+            echo "disabled"
+        fi
+        ;;
+    *)
+        print_help
+        ;;
 esac
 


### PR DESCRIPTION
* Reformat and neaten up code
* Add multi-argument support to enable and disable extensions

e.g. 
```sh
$ gnome-shell-extension-cl -e 'dynamic-panel-transparency@rockon999.github.io' 'focusli@feborg.es'

'dynamic-panel-transparency@rockon999.github.io' is now enabled.
'focusli@feborg.es' is now enabled.
```