### PR TITLE
Fix the handling of no existing enabled extensions

### DIFF
--- a/gnome-shell-extension-cl
+++ b/gnome-shell-extension-cl
@@ -189,7 +189,7 @@ function enable_extension() {
             continue
         fi
         enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
-        [ ! -z "$(echo $enabled_extensions_string | sed -e 's|^@as ||g' | tr -d '[')" ] && delimiter=,
+        [ "$enabled_extensions_string" != "@as [" ] && delimiter=,
         enabled_extensions_string="${enabled_extensions_string}${delimiter} '$extension_to_enable' ]"
 
         gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"

--- a/gnome-shell-extension-cl
+++ b/gnome-shell-extension-cl
@@ -189,7 +189,9 @@ function enable_extension() {
             continue
         fi
         enabled_extensions_string=$(gsettings get org.gnome.shell enabled-extensions | tr -d "]")
-        enabled_extensions_string="$enabled_extensions_string, '$extension_to_enable' ]"
+        [ ! -z "$(echo $enabled_extensions_string | sed -e 's|^@as ||g' | tr -d '[')" ] && delimiter=,
+        enabled_extensions_string="${enabled_extensions_string}${delimiter} '$extension_to_enable' ]"
+
         gsettings set org.gnome.shell enabled-extensions "$enabled_extensions_string"
 
     done


### PR DESCRIPTION
Before, if there's no existing enabled extension yet and you try enabling one extension, you will get an error because there would be an extra comma in the value that `gsettings` tries to set. 

The error msg is like:

```
expected value:
  @as [, 'user-theme@gnome-shell-extensions.gcampax.github.com' ]
       ^                                                         
```

This pull request simply adds a line to test if there's no existing enabled extension.